### PR TITLE
Fix issue with "empty" projects

### DIFF
--- a/KarmaTestAdapter/KarmaTestContainerDiscoverer.cs
+++ b/KarmaTestAdapter/KarmaTestContainerDiscoverer.cs
@@ -80,7 +80,13 @@ namespace KarmaTestAdapter
         {
             foreach (var project in GetProjects())
             {
-                _testFilesUpdateWatcher.AddDirectory(project.GetProjectDirectory());
+                try { 
+                 _testFilesUpdateWatcher.AddDirectory(project.GetProjectDirectory());
+                }
+                catch (ArgumentNullException)
+                {
+                    // do nothing
+                }
             }
         }
 


### PR DESCRIPTION
For some project listed using GetProjects, the method
project.GetMkDocument(VSConstants.VSITEMID_ROOT, out projectPath);
returns not project path. This leads to further errors.
This patch just catches the error raised in VsSolutionHelper.cs
GetProjectPath.

Itermediate fix for bug #1 
