### PR TITLE
Fixing the test FullyQulifiedName

### DIFF
--- a/KarmaTestAdapter/KarmaTestResults/Test.cs
+++ b/KarmaTestAdapter/KarmaTestResults/Test.cs
@@ -40,7 +40,8 @@ namespace KarmaTestAdapter.KarmaTestResults
         {
             get
             {
-                return string.Format("{0}#{1}", Source != null ? Source.FullPath : File.FullPath, Index);
+                //return string.Format("{0}#{1}", Source != null ? Source.FullPath : File.FullPath, Index);
+                return ParentSuite != null ? ParentSuite.DisplayName + "." + Name.Replace(' ', '_') : Name.Replace(' ', '_');
             }
         }
     }


### PR DESCRIPTION
VS is using the test FullyQualifiedName to group tests by "Class".
To do so, it expects the name to be in a standard name format. otherwise it defaults to a class name "test".
